### PR TITLE
Make Course Materials Assistant header visible

### DIFF
--- a/starting-ragchatbot-codebase/frontend/style.css
+++ b/starting-ragchatbot-codebase/frontend/style.css
@@ -135,9 +135,12 @@ body {
     padding: 0;
 }
 
-/* Header - Hidden */
+/* Header */
 header {
-    display: none;
+    padding: 2rem;
+    text-align: center;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border-color);
 }
 
 header h1 {


### PR DESCRIPTION
## Summary
- Made the Course Materials Assistant header visible by updating CSS
- Changed header from `display: none;` to proper styling
- Added padding, centered alignment, and border styling

Fixes #2

Generated with [Claude Code](https://claude.ai/code)